### PR TITLE
Fix/Use autorenew on failed refresh

### DIFF
--- a/src/main/java/no/spid/api/client/SpidApiClient.java
+++ b/src/main/java/no/spid/api/client/SpidApiClient.java
@@ -364,9 +364,8 @@ public class SpidApiClient {
      *
      * @param token the token to refresh
      * @return true if the token could be refreshed, false if not.
-     * @throws SpidOAuthException If an OAuth related error occurs
      */
-    private boolean refreshToken(SpidOAuthToken token) throws SpidOAuthException {
+    private boolean refreshToken(SpidOAuthToken token) {
         OAuthJSONAccessTokenResponse oAuthResponse;
 
         try {
@@ -383,9 +382,9 @@ public class SpidApiClient {
             oAuthResponse = oAuthClient.accessToken(request);
 
         } catch (OAuthSystemException e) {
-            throw new SpidOAuthException(e);
+            return false;
         } catch (OAuthProblemException e) {
-            throw new SpidOAuthException(e);
+            return false;
         }
 
         SpidOAuthToken newToken = new SpidOAuthToken(oAuthResponse.getOAuthToken(), token.getType());


### PR DESCRIPTION
Problem
---
The method ```getAccessToken``` has a chain of actions depending on settings and the state of the OAuth token, the last possible attempt is to try to get a new token if ```autorenew``` is enabled. However if the attempt to refresh the token fails it threw an exception instead of returning false effectively disabling the autorenew attempt.

Solution
--- 
Return false instead of throwing an exception when the refresh fails.